### PR TITLE
Fixed lua errors with EEex

### DIFF
--- a/npc_ee/lib/semi_spont/SEQUENCER_MENU.tpa
+++ b/npc_ee/lib/semi_spont/SEQUENCER_MENU.tpa
@@ -152,8 +152,8 @@
 		local text = ''
 		if bookMode == 1 then
 			if type(SequencerMenu[contingencyResRef]) == 'function' then
-			if SequencerMenuKnown == nil then;	SequencerMenuKnown = 0;	end
-			if SequencerMenuTotal == nil then;	SequencerMenuTotal = 0;	end
+			if SequencerMenuKnown == nil then	SequencerMenuKnown = 0;	end
+			if SequencerMenuTotal == nil then	SequencerMenuTotal = 0;	end
 				text = t("SPELLS_LABEL") .. " :" .. SequencerMenuKnown .. "/" .. SequencerMenuTotal
 			end
 		else
@@ -280,7 +280,7 @@
 		if type(SequencerMenu[abilFunc]) == 'function' then
 			mod = SequencerMenu[abilFunc](abil)
 		end
-		for k,v in pairs (unknown) do;	table.insert(temp, v);	end
+		for k,v in pairs (unknown) do	table.insert(temp, v);	end
 		table.sort(temp,function(a,b) return a.resref < b.resref end)
 		for k,v in ipairs (temp) do
 			if known < num + mod then
@@ -337,13 +337,13 @@
 							PATCH_IF	old < value	BEGIN
 								READ_2DA_ENTRY_FORMER	~READ~	j 0 level
 							//	PATCH_IF	old > 0	BEGIN
-									TEXT_SPRINT	text	~~~~~%text%%else2%if abilVal < %level% then; num = %old%;~~~~~
+									TEXT_SPRINT	text	~~~~~%text%%else2%if abilVal < %level% then num = %old%;~~~~~
 									TEXT_SPRINT	else2	~ else~
 							//	END
 								SET	old = value
 							END
 						END
-						TEXT_SPRINT	text	~~~~~%text% else; num = %value% end%WNL%%TAB%%TAB%~~~~~
+						TEXT_SPRINT	text	~~~~~%text% else num = %value% end%WNL%%TAB%%TAB%~~~~~
 						TEXT_SPRINT	else1	~else~
 					END
 					TEXT_SPRINT	text	~~~~~%text%end~~~~~
@@ -387,16 +387,16 @@
 					PATCH_IF	old < value	BEGIN
 						READ_2DA_ENTRY_FORMER	~READ~	j 0 level
 //						PATCH_IF	old > 0	BEGIN
-							TEXT_SPRINT	text	~~~~~%text%%else2%if level < %level% then; num = %old%;~~~~~
+							TEXT_SPRINT	text	~~~~~%text%%else2%if level < %level% then num = %old%;~~~~~
 							TEXT_SPRINT	else2	~ else~
 //						END
 						SET	old = value
 					END
 				END
 				PATCH_IF	old = 0	BEGIN
-					TEXT_SPRINT	text	~~~~~%text% 0 then; num = 0~~~~~
+					TEXT_SPRINT	text	~~~~~%text% 0 then num = 0~~~~~
 				END
-				TEXT_SPRINT	text	~~~~~%text% else; num = %value% end%WNL%%TAB%%TAB%~~~~~
+				TEXT_SPRINT	text	~~~~~%text% else num = %value% end%WNL%%TAB%%TAB%~~~~~
 				TEXT_SPRINT	else1	~else~
 			END
 			TEXT_SPRINT	text	~~~~~%text%end~~~~~
@@ -612,7 +612,7 @@
 				OUTER_SPRINT script ~%script%%WNL%IF%WNL%True()%WNL%THEN%WNL%RESPONSE #100%WNL%ActionOverride(LastSummonerOf(Myself),ReallyForceSpellRES("%resref%G",Myself))%WNL%DestroySelf()%WNL%END~
 				COMPILE EVAL ~.../%resref%G.baf~
 			END
-			APPEND	~M_SQMENU.LUA~	~~~~~SequencerMenu['%resref%X'] = function(); bookSpells = SequencerMenuSpellsKnown(%multilist%,'%spelltable%','%attrtable%','%abil%',%alignment%,'%postfix%',%global%); end~~~~~
+			APPEND	~M_SQMENU.LUA~	~~~~~SequencerMenu['%resref%X'] = function() bookSpells = SequencerMenuSpellsKnown(%multilist%,'%spelltable%','%attrtable%','%abil%',%alignment%,'%postfix%',%global%); end~~~~~
 		END
 	END
 	


### PR DESCRIPTION
Errors occur when EEex component 1 (Experimental - Use LuaJIT (can help stuttering)) is installed.

```
~CORRECTFRBG2EE/CORRECTFRBG2EE.TP2~ #0 #10 // Correction de la traduction de Baldur's Gate II : Enhanced Edition: 0.22
~CORRECTFRBG2EE/CORRECTFRBG2EE.TP2~ #0 #20 // Patch audio et video francais: 0.22
~EET/EET.TP2~ #3 #0 // EET core (importation de ressource): V13.4
~EEEX/EEEX.TP2~ #0 #0 // EEex: v0.10.2.1-alpha
~EEEX/EEEX.TP2~ #0 #1 // Experimental - Use LuaJIT (can help stuttering): v0.10.2.1-alpha
~EEEX/EEEX.TP2~ #0 #2 // Enable effect menu module - LShift-on-hover to view spells affecting creature: v0.10.2.1-alpha
~EEEX/EEEX.TP2~ #0 #3 // Enable empty container module - Highlight empty containers in gray instead of cyan: v0.10.2.1-alpha
~EEEX/EEEX.TP2~ #0 #4 // Enable timer module - Visual indicators for modal actions, contingencies, and spell/item cooldowns: v0.10.2.1-alpha
~EEEX/EEEX.TP2~ #0 #5 // Timer module - Show modal actions (red bar): v0.10.2.1-alpha
~EEEX/EEEX.TP2~ #0 #6 // Timer module - Show contingencies (green bar): v0.10.2.1-alpha
~EET_END/EET_END.TP2~ #3 #0 // EET end (dernier mod dans l'ordre d'installation) -> Installation standard
~NPC_EE/NPC_EE.TP2~ #1 #2000 // Choix des classes/caracteristiques/kits des PNJ: 6.5
```

![Capture1](https://github.com/UnearthedArcana/NPC_EE/assets/80216629/07b1ecfe-60ff-4ef0-bdf3-a15ca4c97e5d)
![Capture2](https://github.com/UnearthedArcana/NPC_EE/assets/80216629/7454bdcb-170f-47ee-a5f0-f25b2639c6e6)
